### PR TITLE
Fix compiler warning

### DIFF
--- a/synth/spec.hpp
+++ b/synth/spec.hpp
@@ -33,7 +33,7 @@ public:
     uint32_t sol_result;
 
     // The example we are next going to replace
-    int example_iter = 0;
+    uint32_t example_iter = 0;
 
     // The height of the solution circuit.
     const int32_t sol_height;


### PR DESCRIPTION
Fix compiler warnings like:
```
spec.hpp: In member function 'int Spec::advanceCEGISIteration(const Expr*)':
spec.hpp:152:51: warning: comparison of integer expressions of different signedness: 'int' and 'uint32_t' {aka 'unsigned int'} [-Wsign-compare]
  152 |         assert(num_examples == 32 || example_iter == num_examples);
      |                                      ~~~~~~~~~~~~~^~~~~~~~~~~~~~~
In file included from synth_cpu_st.hpp:10:
spec.hpp:153:26: warning: comparison of integer expressions of different signedness: 'int' and 'uint32_t' {aka 'unsigned int'} [-Wsign-compare]
  153 |         if (example_iter >= num_examples) {
      |             ~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```